### PR TITLE
demo: introduce Kyverno policy violations in apigateway deployment

### DIFF
--- a/apps/freshbonds/values.yaml
+++ b/apps/freshbonds/values.yaml
@@ -37,7 +37,7 @@ deployments:
     replicaCount: 1
     image:
       repository: docker.io/emiresh/freshbonds-api-gateway
-      tag: latest  # ⚠️ DEMO: intentional violation - triggers OPA + Kyverno disallow-latest-tag rule
+      tag: v1.0.5
       pullPolicy: IfNotPresent
     service:
       name: apigateway-service
@@ -58,6 +58,18 @@ deployments:
         periodSeconds: 10
         timeoutSeconds: 3
         failureThreshold: 3
+    # ⚠️ DEMO: intentional Kyverno policy violations
+    securityContext:
+      runAsNonRoot: false           # ❌ violates run-as-non-root policy
+      runAsUser: 0                  # ❌ running as root
+      privileged: true              # ❌ violates disallow-privileged policy
+      allowPrivilegeEscalation: true  # ❌ violates disallow-privilege-escalation policy
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop: []                    # ❌ violates drop-all-capabilities policy
+    resources:
+      limits: {}                    # ❌ violates require-resource-limits policy
+      requests: {}
     envFrom:
       - secretRef:
           name: freshbonds-secret


### PR DESCRIPTION
Intentional violations for presentation demo:
- runAsNonRoot: false + runAsUser: 0  → violates run-as-non-root rule
- privileged: true                    → violates disallow-privileged rule
- allowPrivilegeEscalation: true      → violates disallow-privilege-escalation rule
- capabilities.drop: []               → violates drop-all-capabilities rule
- resources.limits: {}                → violates require-resource-limits rule

All 5 Kyverno rules in pod-security.yaml will fire on this PR.